### PR TITLE
Fix #12: PyTorch expects Long rather than Double or Float when computing CrossEntropyLoss

### DIFF
--- a/fl_pytorch/utils/model_funcs.py
+++ b/fl_pytorch/utils/model_funcs.py
@@ -115,7 +115,7 @@ def get_training_elements(model_name, dataset, dataset_ref, args, resume_from, l
     if loss == "crossentropy":
         criterion = nn.CrossEntropyLoss(reduction='sum')
         # CE Loss in Mathematics: CE(P,Q) = - \sum P log(Q) , where P, Q and p.m.f.
-        # CE Loss in Torch: Instead CE(P,Q) we => 
+        # CE Loss in Torch: Instead CE(P,Q) we =>
         #  (step-1) convert and only consider the case when P is a one-hot vector.
         #  (step-2) convert one hot vector for and only consider case when P is one-hot vector.
         #  (step-3) rename P into "target" P'
@@ -905,6 +905,9 @@ def compute_loss(model, criterion, output, label):
 
     if type(criterion) is torch.nn.BCELoss and not label.is_floating_point():
         label = label.float()
+
+    if type(criterion) is torch.nn.CrossEntropyLoss:
+        label = label.long()
 
     if type(output) == list and len(output) > 1:
         if type(model).__name__.lower() == 'inception3':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Please use the following command to install requirements for python/virtualenv
 # python -m pip install -r requirements.txt -f https://download.pytorch.org/whl/cu113/torch_stable.html
 
-torch==1.10.0+cu113
+torch==1.11.0
 torchvision
 numpy
 h5py==3.6.0


### PR DESCRIPTION
This fixes the issue in `utils.models_funcs.compute_loss` where simulations crash when attempting to calculate the Cross Entropy Loss. The labels must be in `Long` format, but they're passed into the function as floating points by default.

Fixes #12 